### PR TITLE
Add ObligatoryPrintDirectives

### DIFF
--- a/soyhtml/directives.go
+++ b/soyhtml/directives.go
@@ -35,6 +35,11 @@ var PrintDirectives = map[string]PrintDirective{
 	"json":              {directiveJson, []int{0}, true},
 }
 
+// ObligatoryPrintDirectives are always called
+// These directives can't take arguments
+// Callers may add their own print directives to this list.
+var ObligatoryPrintDirectiveNames = []string{}
+
 func directiveInsertWordBreaks(value data.Value, args []data.Value) data.Value {
 	var (
 		input    = template.HTMLEscapeString(value.String())

--- a/soyhtml/exec_test.go
+++ b/soyhtml/exec_test.go
@@ -414,6 +414,14 @@ func TestPrintDirectives(t *testing.T) {
 	})
 }
 
+func TestObligatoryDirectives(t *testing.T) {
+	ObligatoryPrintDirectiveNames = []string{"noAutoescape"}
+	runExecTests(t, []execTest{
+		exprtest("obligatory noAutoescape", "{'<a>'}", "<a>"),
+	})
+	ObligatoryPrintDirectiveNames = []string{}
+}
+
 func TestGlobals(t *testing.T) {
 	globals["app.global_str"] = data.New("abc")
 	globals["GLOBAL_INT"] = data.New(5)


### PR DESCRIPTION
This change would allow callers to inject print directives that are applied by default. 

Sometimes we accidentally print null variables, this would allow us to inject a directive that renders these as an empty string instead of as the word 'null'. 